### PR TITLE
Converted driver activity to use fragments for primary view to simplify navigation between panes.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -26,4 +26,5 @@ dependencies {
     compile 'com.google.android.gms:play-services:8.4.0'
     compile 'com.android.support:design:23.1.1'
     compile 'de.hdodenhof:circleimageview:2.0.0'
+    compile 'com.android.support:support-v4:23.1.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,7 @@
             android:value="@string/google_maps_key" />
 
         <activity
-            android:name=".DriverActivity"
+            android:name=".activities.DriverActivity"
             android:label="@string/title_activity_driver">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
+++ b/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
@@ -1,0 +1,91 @@
+package com.mmm.parq.activities;
+
+import android.os.Bundle;
+import android.support.design.widget.NavigationView;
+import android.support.design.widget.Snackbar;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.view.GravityCompat;
+import android.support.v4.widget.DrawerLayout;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.MenuItem;
+import android.view.View;
+
+import com.mmm.parq.R;
+import com.mmm.parq.fragments.DriverHistoryFragment;
+import com.mmm.parq.fragments.DriverHomeFragment;
+import com.mmm.parq.fragments.DriverPaymentFragment;
+import com.mmm.parq.fragments.DriverSettingsFragment;
+
+public class DriverActivity extends FragmentActivity {
+    private DrawerLayout mDrawerLayout;
+    private MenuItem mPreviousItem;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_driver);
+
+        // Set initial fragment as home fragment.
+        Fragment fragment = new DriverHomeFragment();
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        fragmentManager.beginTransaction()
+                .replace(R.id.container, fragment)
+                .commit();
+
+        mDrawerLayout = (DrawerLayout) findViewById(R.id.drawer);
+        NavigationView view = (NavigationView) findViewById(R.id.navigation_view);
+        mPreviousItem = view.getMenu().getItem(0);
+
+        view.setNavigationItemSelectedListener(new NavigationView.OnNavigationItemSelectedListener() {
+            @Override
+            public boolean onNavigationItemSelected(MenuItem menuItem) {
+                Log.d("Driver", "dafuq");
+                Snackbar.make(mDrawerLayout, menuItem.getTitle() + " pressed", Snackbar.LENGTH_LONG).show();
+
+                // Check new item & uncheck old one.
+                menuItem.setChecked(true);
+                if (mPreviousItem != null) {
+                    mPreviousItem.setChecked(false);
+                }
+
+                // Display the fragment corresponding to this menu item.
+                Fragment fragment = null;
+                FragmentManager fragmentManager = getSupportFragmentManager();
+                switch(menuItem.getItemId()) {
+                    case R.id.drawer_home:
+                        fragment = new DriverHomeFragment();
+                        break;
+                    case R.id.drawer_payment:
+                        fragment = new DriverPaymentFragment();
+                        break;
+                    case R.id.drawer_history:
+                        fragment = new DriverHistoryFragment();
+                        break;
+                    case R.id.drawer_settings:
+                        fragment = new DriverSettingsFragment();
+                        break;
+                }
+                fragmentManager.beginTransaction()
+                        .replace(R.id.container, fragment)
+                        .commit();
+                mDrawerLayout.closeDrawers();
+                mPreviousItem = menuItem;
+                return true;
+            }
+        });
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                mDrawerLayout.openDrawer(GravityCompat.START);
+                return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/app/src/main/java/com/mmm/parq/fragments/DriverHistoryFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverHistoryFragment.java
@@ -1,0 +1,20 @@
+package com.mmm.parq.fragments;
+
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.mmm.parq.R;
+
+public class DriverHistoryFragment extends Fragment {
+    public DriverHistoryFragment() {}
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_history_driver, container, false);
+    }
+}

--- a/app/src/main/java/com/mmm/parq/fragments/DriverHomeFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverHomeFragment.java
@@ -1,4 +1,4 @@
-package com.mmm.parq;
+package com.mmm.parq.fragments;
 
 import android.Manifest;
 import android.content.Context;
@@ -7,14 +7,12 @@ import android.location.Location;
 import android.location.LocationManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.design.widget.NavigationView;
-import android.support.design.widget.Snackbar;
 import android.support.v4.app.ActivityCompat;
-import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
-import android.support.v4.view.GravityCompat;
-import android.support.v4.widget.DrawerLayout;
-import android.view.MenuItem;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Toast;
 
 import com.google.android.gms.maps.CameraUpdate;
@@ -23,51 +21,28 @@ import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.LatLng;
+import com.mmm.parq.R;
 
-public class DriverActivity extends FragmentActivity implements OnMapReadyCallback,
-                                                                GoogleMap.OnMyLocationButtonClickListener {
-
+public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
+                                                            GoogleMap.OnMyLocationButtonClickListener {
     private Location mLastLocation;
-
     private GoogleMap mMap;
-    private DrawerLayout drawerLayout;
+
     static private int FINE_LOCATION_PERMISSION_REQUEST_CODE = 0;
     static private int COARSE_LOCATION_PERMISSION_REQUEST_CODE = 1;
 
-    @Override
-    protected void onCreate(Bundle savedInstanceState) {
-        super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_driver);
+    public DriverHomeFragment() {}
 
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_home_driver, container, false);
         // Obtain the SupportMapFragment and get notified when the map is ready to be used.
-        SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager()
+        SupportMapFragment mapFragment = (SupportMapFragment) this.getChildFragmentManager()
                 .findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
 
-        drawerLayout = (DrawerLayout) findViewById(R.id.drawer);
-
-        NavigationView view = (NavigationView) findViewById(R.id.navigation_view);
-        view.setNavigationItemSelectedListener(new NavigationView.OnNavigationItemSelectedListener() {
-            @Override
-            public boolean onNavigationItemSelected(MenuItem menuItem) {
-                Snackbar.make(drawerLayout, menuItem.getTitle() + " pressed", Snackbar.LENGTH_LONG).show();
-                menuItem.setChecked(true);
-                drawerLayout.closeDrawers();
-                return true;
-            }
-        });
-
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                drawerLayout.openDrawer(GravityCompat.START);
-                return true;
-        }
-
-        return super.onOptionsItemSelected(item);
+        return view;
     }
 
     @Override
@@ -81,6 +56,7 @@ public class DriverActivity extends FragmentActivity implements OnMapReadyCallba
                 new LatLng(mLastLocation.getLatitude(), mLastLocation.getLongitude()), 12);
         mMap.animateCamera(cameraUpdate);
     }
+
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
@@ -101,20 +77,20 @@ public class DriverActivity extends FragmentActivity implements OnMapReadyCallba
     }
 
     private void enableMyLocation() {
-        if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
+        if (ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_FINE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(this,
+            ActivityCompat.requestPermissions(getActivity(),
                     new String[]{Manifest.permission.ACCESS_FINE_LOCATION},
                     FINE_LOCATION_PERMISSION_REQUEST_CODE);
-        } else if (ContextCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION)
+        } else if (ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_FINE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(this,
+            ActivityCompat.requestPermissions(getActivity(),
                     new String[]{Manifest.permission.ACCESS_COARSE_LOCATION},
                     COARSE_LOCATION_PERMISSION_REQUEST_CODE);
         } else if (mMap != null) {
             // Access to the location has been granted to the app.
             mMap.setMyLocationEnabled(true);
-            LocationManager locationManager = (LocationManager) this.getSystemService(Context.LOCATION_SERVICE);
+            LocationManager locationManager = (LocationManager) getActivity().getSystemService(Context.LOCATION_SERVICE);
             String locationProvider = LocationManager.NETWORK_PROVIDER;
             mLastLocation = locationManager.getLastKnownLocation(locationProvider);
         }
@@ -122,10 +98,9 @@ public class DriverActivity extends FragmentActivity implements OnMapReadyCallba
 
     @Override
     public boolean onMyLocationButtonClick() {
-        Toast.makeText(this, "MyLocation button clicked", Toast.LENGTH_SHORT).show();
+        Toast.makeText(getActivity(), "MyLocation button clicked", Toast.LENGTH_SHORT).show();
         // Return false so that we don't consume the event and the default behavior still occurs
         // (the camera animates to the user's current position).
         return false;
     }
-
 }

--- a/app/src/main/java/com/mmm/parq/fragments/DriverPaymentFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverPaymentFragment.java
@@ -1,0 +1,19 @@
+package com.mmm.parq.fragments;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.mmm.parq.R;
+
+public class DriverPaymentFragment extends Fragment {
+    public DriverPaymentFragment() {}
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        return inflater.inflate(R.layout.fragment_payment_driver, container, false);
+    }
+}

--- a/app/src/main/java/com/mmm/parq/fragments/DriverSettingsFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverSettingsFragment.java
@@ -1,0 +1,73 @@
+package com.mmm.parq.fragments;
+
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import com.mmm.parq.R;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class DriverSettingsFragment extends Fragment {
+    private RecyclerView mRecyclerView;
+    private ItemAdapter mItemAdapter;
+
+    public DriverSettingsFragment() {}
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View view =  inflater.inflate(R.layout.fragment_settings_driver, container, false);
+        mRecyclerView = (RecyclerView) view.findViewById(R.id.settings_recycler);
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
+        mItemAdapter = new ItemAdapter();
+        mRecyclerView.setAdapter(mItemAdapter);
+
+        return view;
+    }
+
+    private class ItemHolder extends RecyclerView.ViewHolder {
+        public TextView mTextView;
+
+        public ItemHolder(View itemView) {
+            super(itemView);
+            mTextView = (TextView) itemView;
+        }
+    }
+
+    private class ItemAdapter extends RecyclerView.Adapter<ItemHolder> {
+        private List<String> mItems;
+
+        public ItemAdapter() {
+            mItems = new ArrayList<>();
+            mItems.add("Notifications");
+            mItems.add("Logout");
+        }
+
+        @Override
+        public ItemHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+            LayoutInflater layoutInflater = LayoutInflater.from(getActivity());
+            View view = layoutInflater.inflate(android.R.layout.simple_list_item_1, parent, false);
+            return new ItemHolder(view);
+        }
+
+        @Override
+        public void onBindViewHolder(ItemHolder holder, int position) {
+            String item = mItems.get(position);
+            holder.mTextView.setText(item);
+        }
+
+        @Override
+        public int getItemCount() {
+            return mItems.size();
+        }
+    }
+
+}

--- a/app/src/main/res/layout/activity_driver.xml
+++ b/app/src/main/res/layout/activity_driver.xml
@@ -6,24 +6,10 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     tools:context=".MainActivity">
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent" >
-
-        <fragment xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:tools="http://schemas.android.com/tools"
-            android:id="@+id/map"
-            android:name="com.google.android.gms.maps.SupportMapFragment"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            tools:context="com.mmm.parq.DriverActivity" />
-        <Button
-            android:text="@string/find_spot_button_text"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerHorizontal="true"
-            android:layout_alignParentBottom="true" />
-    </RelativeLayout>
+        android:layout_height="match_parent"
+        android:id="@+id/container"/>
     <android.support.design.widget.NavigationView
         android:id="@+id/navigation_view"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/fragment_history_driver.xml
+++ b/app/src/main/res/layout/fragment_history_driver.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Driver History \n Fragment Placeholder"
+        android:textSize="24sp"
+        android:gravity="center"/>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_home_driver.xml
+++ b/app/src/main/res/layout/fragment_home_driver.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:id="@+id/map"
+        android:name="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".activities.DriverActivity" />
+    <Button
+        android:text="@string/find_spot_button_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_alignParentBottom="true" />
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_payment_driver.xml
+++ b/app/src/main/res/layout/fragment_payment_driver.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Driver Payment \n Fragment Placeholder"
+        android:textSize="24sp"
+        android:gravity="center"/>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_settings_driver.xml
+++ b/app/src/main/res/layout/fragment_settings_driver.xml
@@ -1,0 +1,10 @@
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <android.support.v7.widget.RecyclerView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/settings_recycler">
+    </android.support.v7.widget.RecyclerView>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,4 +6,7 @@
     <string name="history">History</string>
     <string name="settings">Settings</string>
     <string name="find_spot_button_text">Find Spot</string>
+
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
<h1> Fragmentation </h1>

<h2> What? </h2>

This PR moves everything in our primary driver view from the DriverActivity into a fragment. It also adds placeholder fragments for each of the other primary driver views (payment, history, and settings).

<h2> Why? </h2>

Navigation is much simpler if we just switch out a fragment each time a menu item is selected. Thus, it made sense to remove the substantive view from the activity. Now the activity code just handles the nav drawer, and fragment views handle the content that's actually on the screen. I think this division also ends up making the code easier to understand. 

Functionally this doesn't change much, but the code changes appear significant even though they aren't really.

@nickcharles @matthewgrossman 
