### PR TITLE
Implements navigation in gmaps & displays occupied card after returning

### DIFF
--- a/app/src/main/java/com/mmm/parq/layouts/OccupiedSpotCardView.java
+++ b/app/src/main/java/com/mmm/parq/layouts/OccupiedSpotCardView.java
@@ -1,0 +1,73 @@
+package com.mmm.parq.layouts;
+
+import android.app.Activity;
+import android.content.Context;
+import android.support.v7.widget.CardView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.widget.TextView;
+
+import com.mmm.parq.R;
+import com.mmm.parq.models.Spot;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+public class OccupiedSpotCardView extends CardView {
+    private Timer mTimer;
+    private TextView mTimeElapsedText;
+    private TextView mNetCostText;
+    private TextView mAddr;
+    private int mTimeElapsed;
+    private int mNetCost;
+
+    private static int ONE_MINUTE = 60000;
+
+    public OccupiedSpotCardView(final Activity activity, Spot spot) {
+        super(activity);
+        final int rate = Integer.parseInt(spot.getAttribute("costPerHour"));
+        String addr = spot.getAttribute("addr");
+
+        LayoutInflater inflater = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        View view = inflater.inflate(R.layout.occupied_spot_card, null);
+        mTimeElapsed = 0;
+        mNetCost = 0;
+
+        mTimeElapsedText = (TextView) view.findViewById(R.id.time_elapsed);
+        mNetCostText = (TextView) view.findViewById(R.id.net_cost);
+        mAddr = (TextView) view.findViewById(R.id.addr);
+        mAddr.setText(addr);
+
+        // Update spot timer and net cost every minute.
+        mTimer = new Timer();
+        TimerTask timerTask = new TimerTask() {
+            @Override
+            public void run() {
+
+                activity.runOnUiThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        mTimeElapsedText.setText(intToTimeString(mTimeElapsed));
+                        mNetCostText.setText(String.format(activity.getString(R.string.cost), mNetCost));
+                        mTimeElapsed += 1;
+                        mNetCost += rate;
+                    }
+                });
+            }
+        };
+        mTimer.schedule(timerTask, 0, ONE_MINUTE);
+
+        addView(view);
+    }
+
+    private String intToTimeString(int timeInMinutes) {
+        int hours = timeInMinutes / 60;
+        int minutes = timeInMinutes % 60;
+
+        if (hours > 0) {
+            return String.format("%d:%02d", hours, minutes);
+        } else {
+            return String.valueOf(minutes);
+        }
+    }
+}

--- a/app/src/main/res/layout/occupied_spot_card.xml
+++ b/app/src/main/res/layout/occupied_spot_card.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.CardView xmlns:card_view="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_height="wrap_content"
+    android:layout_width="380dp"
+    xmlns:tools="http://schemas.android.com/tools">
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+        <!-- This is a placeholder image view  -->
+        <ImageView
+            android:id="@+id/spot_image"
+            android:layout_width="380dp"
+            android:layout_height="90dp"
+            android:src="@drawable/temp_spot" />
+        <TextView
+            android:id="@+id/addr"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:textSize="18sp"
+            tools:text="123 South University Ave"/>
+        <LinearLayout
+            android:id="@+id/main_layout"
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+            <LinearLayout
+                android:padding="8dp"
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:layout_gravity="center"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+                <TextView
+                    android:id="@+id/time_elapsed"
+                    android:layout_weight="1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textAlignment="center"
+                    android:textSize="24sp"
+                    tools:text="1:15"/>
+                <TextView
+                    android:text="@string/time_parked"
+                    android:textAlignment="center"
+                    android:textSize="11sp"
+                    android:layout_weight="1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+
+            </LinearLayout>
+            <View
+                android:layout_gravity="center"
+                android:layout_width="2dp"
+                android:layout_height="40dp"
+                android:background="#000"/>
+            <LinearLayout
+                android:layout_weight="1"
+                android:orientation="vertical"
+                android:layout_gravity="center"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+                <TextView
+                    android:id="@+id/net_cost"
+                    android:layout_weight="1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textSize="24sp"
+                    android:textAlignment="center"
+                    tools:text="$6"/>
+                <TextView
+                    android:text="@string/net_cost"
+                    android:textAlignment="center"
+                    android:textSize="11sp"
+                    android:layout_weight="1"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content" />
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</android.support.v7.widget.CardView>

--- a/app/src/main/res/layout/reserved_spot_card.xml
+++ b/app/src/main/res/layout/reserved_spot_card.xml
@@ -39,12 +39,12 @@
             android:layout_height="20dp"
             android:layout_marginTop="2dp"
             android:layout_marginBottom="8dp"
-            android:orientation="horizontal"
             android:layout_below="@+id/addr_and_time">
             <LinearLayout
                 android:id="@+id/rating"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:orientation="horizontal"
                 android:gravity="center_vertical"
                 android:layout_marginStart="8dp">
             </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,9 +7,16 @@
     <string name="settings">Settings</string>
     <string name="find_spot_button_text">Find Spot</string>
     <string name="navigate_text">Navigate to spot</string>
+    <string name="end_reservation">Leave spot</string>
+    <string name="end_transaction_text"></string>
     <string name="api_address">http://162.243.244.79</string>
-    <string name="reservations_endpint">reservations</string>
+    <string name="reservations_endpoint">reservations</string>
     <string name="spots_endpoint">spots</string>
     <string name="google_directions_endpoint">https://maps.googleapis.com/maps/api/directions/json</string>
     <string name="no_ratings">No ratings</string>
+    <string name="nav_intent_uri">google.navigation:q=%1$s,%2$s</string>
+    <string name="maps_package">com.google.android.apps.maps</string>
+    <string name="cost">$%1$d</string>
+    <string name="time_parked">Time parked</string>
+    <string name="net_cost">Net cost</string>
 </resources>


### PR DESCRIPTION
<h1> What? </h1>
- Clicking on 'Navigate to spot' in the driver home fragment opens navigation to the spot in google maps
- After returning from navigation, the home fragment displays a card including info about the spot, the amount of time the spot has been occupied, and the net cost

![image](https://cloud.githubusercontent.com/assets/3460565/13558078/095af274-e3c9-11e5-9faf-eb8bc1461388.png)

<h1> Related pending issues: </h1> 
#6 #7

@matthewgrossman @nickcharles 
