### PR TITLE
Kenz/state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <!--
          The ACCESS_COARSE/FINE_LOCATION permissions are not required to use
          Google Maps Android API v2, but you must specify either coarse or fine
-         location permissions for the 'MyLocation' functionality. 
+         location permissions for the 'MyLocation' functionality.
     -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
+++ b/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
@@ -39,7 +39,6 @@ public class DriverActivity extends FragmentActivity implements
     private DrawerLayout mDrawerLayout;
     private Fragment mFragment;
     private MenuItem mPreviousItem;
-    private MenuItem mHostItem;
     private Reservation mReservation;
     private Spot mSpot;
     private Location mUserLocation;

--- a/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
+++ b/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
@@ -76,7 +76,6 @@ public class DriverActivity extends FragmentActivity implements
 
         // Restore state
         if (savedInstanceState != null) {
-            Log.d("tag", "Restoring!");
             mSpot = (Spot) savedInstanceState.get("spot");
             mReservation = (Reservation) savedInstanceState.get("reservation");
         } else {
@@ -182,13 +181,6 @@ public class DriverActivity extends FragmentActivity implements
         if (mSpot != null) {
             savedInstanceState.putSerializable("spot", mSpot);
         }
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-
-        Log.d("DriverActivity", "in onDestroy!");
     }
 
     // Fragment Callbacks

--- a/app/src/main/java/com/mmm/parq/fragments/DriverFindSpotFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverFindSpotFragment.java
@@ -16,6 +16,7 @@ import com.android.volley.RequestQueue;
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
 import com.android.volley.toolbox.StringRequest;
+import com.firebase.client.Firebase;
 import com.google.gson.Gson;
 import com.mmm.parq.R;
 import com.mmm.parq.activities.DriverActivity;
@@ -33,7 +34,7 @@ public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
     private OnReservationCreatedListener mCallback;
     private RequestQueue mQueue;
 
-    private final String TAG = this.getTag();
+    private final String TAG = DriverFindSpotFragment.class.getSimpleName();
 
     public interface OnReservationCreatedListener {
         void setReservation(Reservation reservation);
@@ -88,7 +89,7 @@ public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
                 fragmentTransaction.replace(R.id.driver_fragment_container, driverNavigationFragment);
                 ((DriverActivity) getActivity()).setState(DriverHomeFragment.State.NAVIGATION);
                 fragmentTransaction.commit();
-                ((DriverActivity)getActivity()).shareLocation();
+                ((DriverActivity) getActivity()).shareLocation();
             }
 
             @Override
@@ -115,8 +116,8 @@ public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
             @Override
             protected Map<String, String> getParams() {
                 Map<String, String>  params = new HashMap<>();
-                // TODO(kenzshelley) REPLACE THIS WITH TRUE USERID AFTER IMPLEMENTING LOGIN
-                params.put("userId", "2495cce6-0fa1-4a12-88d3-84a062832673");
+                Firebase firebaseRef = new Firebase(getString(R.string.firebase_endpoint));
+                params.put("userId", firebaseRef.getAuth().getUid());
                 params.put("latitude", String.valueOf(mLocation.getLatitude()));
                 params.put("longitude", String.valueOf(mLocation.getLongitude()));
                 return params;

--- a/app/src/main/java/com/mmm/parq/fragments/DriverFindSpotFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverFindSpotFragment.java
@@ -18,6 +18,7 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.StringRequest;
 import com.google.gson.Gson;
 import com.mmm.parq.R;
+import com.mmm.parq.activities.DriverActivity;
 import com.mmm.parq.models.Reservation;
 import com.mmm.parq.utils.HttpClient;
 import com.mmm.parq.utils.NeedsLocation;
@@ -32,7 +33,7 @@ public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
     private OnReservationCreatedListener mCallback;
     private RequestQueue mQueue;
 
-    private static final String CLASS = "DriverFindSpot";
+    private final String TAG = this.getTag();
 
     public interface OnReservationCreatedListener {
         void setReservation(Reservation reservation);
@@ -40,6 +41,7 @@ public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
 
     public DriverFindSpotFragment() {}
 
+    @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_find_spot_driver, container, false);
@@ -55,6 +57,17 @@ public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
         });
 
         return view;
+    }
+
+    @Override
+    public void onAttach(Context activity) {
+        super.onAttach(activity);
+
+        try {
+            mCallback = (OnReservationCreatedListener) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString() + " must implement interface");
+        }
     }
 
     public void setLocation(Location location) {
@@ -73,12 +86,14 @@ public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
                 DriverNavigationFragment driverNavigationFragment = new DriverNavigationFragment();
                 FragmentTransaction fragmentTransaction = getFragmentManager().beginTransaction();
                 fragmentTransaction.replace(R.id.driver_fragment_container, driverNavigationFragment);
+                ((DriverActivity) getActivity()).setState(DriverHomeFragment.State.NAVIGATION);
                 fragmentTransaction.commit();
+                ((DriverActivity)getActivity()).shareLocation();
             }
 
             @Override
             public void onError(VolleyError error) {
-                Log.d(CLASS + ":Error", error.toString());
+                Log.d(TAG + ":Error", error.toString());
             }
         });
     }
@@ -109,16 +124,5 @@ public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
         };
 
         mQueue.add(reservationRequest);
-    }
-
-    @Override
-    public void onAttach(Context activity) {
-        super.onAttach(activity);
-
-        try {
-            mCallback = (OnReservationCreatedListener) activity;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(activity.toString() + " must implement interface");
-        }
     }
 }

--- a/app/src/main/java/com/mmm/parq/fragments/DriverFindSpotFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverFindSpotFragment.java
@@ -1,0 +1,124 @@
+package com.mmm.parq.fragments;
+
+import android.content.Context;
+import android.location.Location;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.Response;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.StringRequest;
+import com.google.gson.Gson;
+import com.mmm.parq.R;
+import com.mmm.parq.models.Reservation;
+import com.mmm.parq.utils.HttpClient;
+import com.mmm.parq.utils.NeedsLocation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
+    private Button mFindParkingButton;
+    private Gson mGson;
+    private Location mLocation;
+    private OnReservationCreatedListener mCallback;
+    private RequestQueue mQueue;
+
+    private static final String CLASS = "DriverFindSpot";
+
+    public interface OnReservationCreatedListener {
+        void setReservation(Reservation reservation);
+    }
+
+    public DriverFindSpotFragment() {}
+
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_find_spot_driver, container, false);
+
+        mGson = new Gson();
+        mQueue = HttpClient.getInstance(getActivity().getApplicationContext()).getRequestQueue();
+        mFindParkingButton = (Button) view.findViewById(R.id.findparkingbutton);
+        mFindParkingButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                reserveSpot();
+            }
+        });
+
+        return view;
+    }
+
+    public void setLocation(Location location) {
+        mLocation = location;
+    }
+
+    private void reserveSpot() {
+        requestReservation(new HttpClient.VolleyCallback<String>() {
+            @Override
+            public void onSuccess(String response) {
+                // Parse the reservation response into a Reservation, send it to activity.
+                Reservation reservation = mGson.fromJson(response, Reservation.class);
+                mCallback.setReservation(reservation);
+
+                // Start the navigation fragment.
+                DriverNavigationFragment driverNavigationFragment = new DriverNavigationFragment();
+                FragmentTransaction fragmentTransaction = getFragmentManager().beginTransaction();
+                fragmentTransaction.replace(R.id.driver_fragment_container, driverNavigationFragment);
+                fragmentTransaction.commit();
+            }
+
+            @Override
+            public void onError(VolleyError error) {
+                Log.d(CLASS + ":Error", error.toString());
+            }
+        });
+    }
+
+    // Send a request to create a reservation for the current user from the reservations endpoint.
+    private void requestReservation(final HttpClient.VolleyCallback<String> callback) {
+        String url = String.format("%s/%s", getString(R.string.api_address), getString(R.string.reservations_endpoint));
+        StringRequest reservationRequest = new StringRequest(Request.Method.POST, url, new Response.Listener<String>() {
+            @Override
+            public void onResponse(String response) {
+                callback.onSuccess(response);
+            }
+        }, new Response.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError error) {
+                callback.onError(error);
+            }
+        }) {
+            @Override
+            protected Map<String, String> getParams() {
+                Map<String, String>  params = new HashMap<>();
+                // TODO(kenzshelley) REPLACE THIS WITH TRUE USERID AFTER IMPLEMENTING LOGIN
+                params.put("userId", "2495cce6-0fa1-4a12-88d3-84a062832673");
+                params.put("latitude", String.valueOf(mLocation.getLatitude()));
+                params.put("longitude", String.valueOf(mLocation.getLongitude()));
+                return params;
+            }
+        };
+
+        mQueue.add(reservationRequest);
+    }
+
+    @Override
+    public void onAttach(Context activity) {
+        super.onAttach(activity);
+
+        try {
+            mCallback = (OnReservationCreatedListener) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString() + " must implement interface");
+        }
+    }
+}

--- a/app/src/main/java/com/mmm/parq/fragments/DriverHomeFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverHomeFragment.java
@@ -141,7 +141,6 @@ public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
         fragmentTransaction.replace(R.id.driver_fragment_container, driverOccupiedSpotFragment);
         mState = State.OCCUPY_SPOT;
         fragmentTransaction.commit();
-        ((DriverActivity)getActivity()).shareLocation();
     }
 
     @Override

--- a/app/src/main/java/com/mmm/parq/fragments/DriverHomeFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverHomeFragment.java
@@ -9,11 +9,11 @@ import android.graphics.Color;
 import android.graphics.Point;
 import android.location.Location;
 import android.location.LocationManager;
-import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
 import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.Display;
@@ -43,45 +43,28 @@ import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.google.android.gms.maps.model.Polyline;
 import com.google.android.gms.maps.model.PolylineOptions;
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.reflect.TypeToken;
 import com.mmm.parq.R;
-import com.mmm.parq.exceptions.RouteNotFoundException;
-import com.mmm.parq.layouts.OccupiedSpotCardView;
-import com.mmm.parq.layouts.ReservedSpotCardView;
-import com.mmm.parq.models.Reservation;
-import com.mmm.parq.models.Spot;
-import com.mmm.parq.utils.ConversionUtils;
-import com.mmm.parq.utils.DirectionsParser;
-import com.mmm.parq.utils.HttpClient;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
                                                             GoogleMap.OnMyLocationButtonClickListener {
     private Location mLastLocation;
     private GoogleMap mMap;
-    private Button mFindParkingButton;
-    private RequestQueue mQueue;
-    private Gson mGson;
-    private RelativeLayout mRelativeLayout;
-    private Spot mCurrentSpot;
     private Polyline mDirectionsPath;
+    private OnLocationReceivedListener mCallback;
 
-    static private int FINE_LOCATION_PERMISSION_REQUEST_CODE = 0;
-    static private int COARSE_LOCATION_PERMISSION_REQUEST_CODE = 1;
-    static private int ZOOM_LEVEL = 16;
-    static private int CARD_WIDTH = 380;
-    static private int CARD_BOTTOM_MARGIN = 4;
-    static private int LINE_WIDTH = 20;
-
-    static private int MAPS_REQUEST_CODE = 1;
+    static private final int COARSE_LOCATION_PERMISSION_REQUEST_CODE = 1;
+    static private final int FINE_LOCATION_PERMISSION_REQUEST_CODE = 0;
+    static private final int LINE_WIDTH = 20;
+    static private final int MAPS_REQUEST_CODE = 1;
+    static private final int ZOOM_LEVEL = 16;
 
     static private String CLASS = "DriverHomeFragment";
+
+    public interface OnLocationReceivedListener {
+        void setLocation(Location location);
+    }
 
     public DriverHomeFragment() {}
 
@@ -89,232 +72,17 @@ public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_home_driver, container, false);
+
         // Obtain the SupportMapFragment and get notified when the map is ready to be used.
         SupportMapFragment mapFragment = (SupportMapFragment) this.getChildFragmentManager()
                 .findFragmentById(R.id.map);
         mapFragment.getMapAsync(this);
-        mQueue = HttpClient.getInstance(getActivity().getApplicationContext()).getRequestQueue();
-        mGson = new Gson();
-        mRelativeLayout = (RelativeLayout) view.findViewById(R.id.driver_home_layout);
-        mCurrentSpot = null;
 
-        mQueue = HttpClient.getInstance(getActivity().getApplicationContext()).getRequestQueue();
-        mFindParkingButton = (Button) view.findViewById(R.id.findparkingbutton);
-        mFindParkingButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                // If the button is in 'find spot' mode, reserve a spot
-                if (getString(R.string.find_spot_button_text).equals(mFindParkingButton.getText())) {
-                    // Reserve a spot for the user.
-                    reserveSpot();
-                } else {
-                    // Otherwise, navigate to the spot
-                    // TODO(kenzshelley) actually send an intent to navigate to the currently reserved spot.
-                    if (mCurrentSpot == null) {
-                        Log.d(CLASS, "No spot has been reserved!");
-                    } else {
-                        startNavigation();
-                    }
-                }
-            }
-        });
+        DriverFindSpotFragment driverFindSpotFragment = new DriverFindSpotFragment();
+        getChildFragmentManager().beginTransaction()
+                .add(R.id.driver_fragment_container, driverFindSpotFragment).commit();
 
         return view;
-    }
-
-    private void startNavigation() {
-        LatLong latLong = GeoHash.decodeHash(mCurrentSpot.getAttribute("geohash"));
-        String uriString = String.format(getString(R.string.nav_intent_uri),
-                latLong.getLat(), latLong.getLon());
-        Uri gmmIntentUri = Uri.parse(uriString);
-        Intent mapIntent = new Intent(Intent.ACTION_VIEW, gmmIntentUri);
-        mapIntent.setPackage(getString(R.string.maps_package));
-
-        startActivityForResult(mapIntent, MAPS_REQUEST_CODE);
-    }
-
-    private void reserveSpot() {
-        requestReservation(new HttpClient.VolleyCallback<String>() {
-            @Override
-            public void onSuccess(String response) {
-                // Parse the reservation response into a Reservation
-                final Reservation res = mGson.fromJson(response, Reservation.class);
-
-                // Request directions to the reserved spot using Google Directions API
-                String geohash = res.getAttribute("geohash");
-                final LatLong latLong = GeoHash.decodeHash(geohash);
-                requestDirections(latLong, new HttpClient.VolleyCallback<String>() {
-                    @Override
-                    public void onSuccess(String directionsResponse) {
-                        DirectionsParser parser = new DirectionsParser(directionsResponse);
-
-                        // Display the route on the map
-                        drawDirectionsPath(parser, latLong);
-                        final String timeToSpot = parser.parseTime();
-
-                        // Update the button
-                        mFindParkingButton.setText(getString(R.string.navigate_text));
-                        Log.d(CLASS, "ABOUT TO REQUEST SPOT");
-
-                        // Request the spot for this reservation
-                        requestSpot(res.getAttribute("spotId"), new HttpClient.VolleyCallback<String>() {
-                            @Override
-                            public void onSuccess(String spotResponse) {
-                                showSpotCard(spotResponse, timeToSpot);
-                            }
-
-                            @Override
-                            public void onError(VolleyError error) {
-                                Log.d(CLASS, error.toString());
-                            }
-                        });
-                    }
-
-                    @Override
-                    public void onError(VolleyError error) {
-                        Log.d(CLASS, error.getMessage());
-                    }
-                });
-            }
-
-            @Override
-            public void onError(VolleyError error) {
-                Log.d(CLASS + ":Error", error.toString());
-            }
-        });
-    }
-
-    private Spot parseSpotResponse(String response) {
-        JsonParser parser = new JsonParser();
-        JsonObject spotObj = parser.parse(response).getAsJsonObject();
-        String id = spotObj.get("id").getAsString();
-        JsonObject attrObj = spotObj.get("attributes").getAsJsonObject();
-        HashMap<String, String> attrs = mGson.fromJson(attrObj, new TypeToken<HashMap<String, String>>(){}.getType());
-
-        return new Spot(id, attrs);
-    }
-
-    private void requestSpot(String spotId, final HttpClient.VolleyCallback<String> callback) {
-        // Request the spot
-        String url = String.format("%s/%s/%s", getString(R.string.api_address),
-                getString(R.string.spots_endpoint), spotId);
-        StringRequest spotRequest = new StringRequest(Request.Method.GET, url, new Response.Listener<String>() {
-            @Override
-            public void onResponse(String response) {
-                callback.onSuccess(response);
-            }
-        }, new Response.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError error) {
-                callback.onError(error);
-
-            }
-        });
-
-        mQueue.add(spotRequest);
-    }
-
-    private void showSpotCard(String spotResponse, String timeToSpot) {
-        Spot spot = parseSpotResponse(spotResponse);
-        // set this as the current local spot
-        mCurrentSpot = spot;
-
-        ReservedSpotCardView reservedSpotCardView = new ReservedSpotCardView(getActivity(), spot, timeToSpot);
-        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ConversionUtils.dpToPx(getActivity(), CARD_WIDTH),
-                RelativeLayout.LayoutParams.WRAP_CONTENT);
-        params.addRule(RelativeLayout.ABOVE, R.id.findparkingbutton);
-        params.addRule(RelativeLayout.CENTER_HORIZONTAL);
-        params.bottomMargin = ConversionUtils.dpToPx(getActivity(), CARD_BOTTOM_MARGIN);
-
-        mRelativeLayout.addView(reservedSpotCardView, params);
-    }
-
-    // Send a request to create a reservation for the current user from the reservations endpoint.
-    private void requestReservation(final HttpClient.VolleyCallback<String> callback) {
-        String url = String.format("%s/%s", getString(R.string.api_address), getString(R.string.reservations_endpoint));
-        StringRequest reservationRequest = new StringRequest(Request.Method.POST, url, new Response.Listener<String>() {
-            @Override
-            public void onResponse(String response) {
-                callback.onSuccess(response);
-            }
-        }, new Response.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError error) {
-                callback.onError(error);
-            }
-        }) {
-            @Override
-            protected Map<String, String> getParams() {
-                Map<String, String>  params = new HashMap<>();
-                Firebase firebaseRef = new Firebase(getString(R.string.firebase_endpoint));
-                // TODO(kenzshelley) REPLACE THIS WITH TRUE USERID AFTER IMPLEMENTING LOGIN
-                params.put("userId", firebaseRef.getAuth().getUid());
-                params.put("latitude", String.valueOf(mLastLocation.getLatitude()));
-                params.put("longitude", String.valueOf(mLastLocation.getLongitude()));
-                return params;
-            }
-        };
-
-        mQueue.add(reservationRequest);
-    }
-
-    // Send a request to Google Directions API for directions from the user's current location to their
-    // reserved spot.
-    private void requestDirections(LatLong latLong, final HttpClient.VolleyCallback<String> callback) {
-        String apiKey = getString(R.string.google_maps_key);
-
-        // Request directions
-        String directionsUrl = String.format("%s?origin=%f,%f&destination=%f,%f&key=%s\t\n",
-                getString(R.string.google_directions_endpoint),
-                mLastLocation.getLatitude(), mLastLocation.getLongitude(), latLong.getLat(),
-                latLong.getLon(), apiKey);
-        StringRequest directionsRequest = new StringRequest(Request.Method.GET, directionsUrl, new Response.Listener<String>() {
-            @Override
-            public void onResponse(String response) {
-               callback.onSuccess(response);
-            }
-        }, new Response.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError error) {
-                callback.onError(error);
-            }
-        });
-
-        mQueue.add(directionsRequest);
-    }
-
-    private void drawDirectionsPath(DirectionsParser parser, LatLong latLong) {
-        // Parse the directions api response
-        try {
-            List<LatLng> path = parser.parsePath();
-            PolylineOptions polylineOptions = new PolylineOptions();
-            polylineOptions.addAll(path);
-            polylineOptions.width(LINE_WIDTH);
-            polylineOptions.color(Color.BLUE);
-
-            // add start and end markers
-            Marker dest = mMap.addMarker(new MarkerOptions().position(new LatLng(latLong.getLat(), latLong.getLon())));
-            Marker start = mMap.addMarker(new MarkerOptions().position(new LatLng(mLastLocation.getLatitude(),
-                    mLastLocation.getLongitude())));
-            mDirectionsPath = mMap.addPolyline(polylineOptions);
-
-            // get the size of the screen
-            Activity activity = this.getActivity();
-            WindowManager wm = (WindowManager) activity.getSystemService(Context.WINDOW_SERVICE);
-            Display display = wm.getDefaultDisplay();
-            Point size = new Point();
-            display.getSize(size);
-
-            // make a lat long bounds and move the camera to it
-            LatLngBounds.Builder builder = new LatLngBounds.Builder();
-            builder.include(start.getPosition()).include(dest.getPosition());
-            LatLngBounds bounds = builder.build();
-            CameraUpdate cameraUpdate = CameraUpdateFactory.newLatLngBounds(bounds, 150);
-            mMap.setPadding(0, 0, 0, size.y / 2);
-            mMap.animateCamera(cameraUpdate);
-        } catch (RouteNotFoundException e) {
-            Log.d(CLASS, "No route found: " + e.toString());
-        }
     }
 
     @Override
@@ -345,6 +113,70 @@ public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
         }
     }
 
+    @Override
+    public boolean onMyLocationButtonClick() {
+        // Return false so that we don't consume the event and the default behavior still occurs
+        // (the camera animates to the user's current position).
+        return false;
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode != MAPS_REQUEST_CODE) return;
+
+        // Switch to DriverOccupiedSpotFragment
+        DriverOccupiedSpotFragment driverOccupiedSpotFragment = new DriverOccupiedSpotFragment();
+        FragmentTransaction fragmentTransaction = getFragmentManager().beginTransaction();
+        fragmentTransaction.replace(R.id.driver_fragment_container, driverOccupiedSpotFragment);
+        fragmentTransaction.commit();
+    }
+
+    @Override
+    public void onAttach(Context activity) {
+        super.onAttach(activity);
+
+        try {
+            mCallback = (OnLocationReceivedListener) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString() + " must implement interface");
+        }
+    }
+
+    public void addPath(List<LatLng> path, LatLong latLong) {
+        PolylineOptions polylineOptions = new PolylineOptions();
+        polylineOptions.addAll(path);
+        polylineOptions.width(LINE_WIDTH);
+        polylineOptions.color(Color.BLUE);
+
+        // add start and end markers
+        Marker dest = mMap.addMarker(new MarkerOptions().position(new LatLng(latLong.getLat(), latLong.getLon())));
+        Marker start = mMap.addMarker(new MarkerOptions().position(new LatLng(mLastLocation.getLatitude(),
+                mLastLocation.getLongitude())));
+        mDirectionsPath = mMap.addPolyline(polylineOptions);
+
+        // get the size of the screen
+        Activity activity = this.getActivity();
+        WindowManager wm = (WindowManager) activity.getSystemService(Context.WINDOW_SERVICE);
+        Display display = wm.getDefaultDisplay();
+        Point size = new Point();
+        display.getSize(size);
+
+        // make a lat long bounds and move the camera to it
+        LatLngBounds.Builder builder = new LatLngBounds.Builder();
+        builder.include(start.getPosition()).include(dest.getPosition());
+        LatLngBounds bounds = builder.build();
+        CameraUpdate cameraUpdate = CameraUpdateFactory.newLatLngBounds(bounds, 150);
+        mMap.setPadding(0, 0, 0, size.y / 2);
+        mMap.animateCamera(cameraUpdate);
+    }
+
+    public void removePath() {
+        if (mDirectionsPath == null) {
+            Log.d(CLASS, "No path to remove!");
+        }
+        mDirectionsPath.remove();
+    }
+
     private void enableMyLocation() {
         if (ContextCompat.checkSelfPermission(getActivity(), Manifest.permission.ACCESS_FINE_LOCATION)
                 != PackageManager.PERMISSION_GRANTED) {
@@ -362,34 +194,7 @@ public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
             LocationManager locationManager = (LocationManager) getActivity().getSystemService(Context.LOCATION_SERVICE);
             String locationProvider = LocationManager.NETWORK_PROVIDER;
             mLastLocation = locationManager.getLastKnownLocation(locationProvider);
+            mCallback.setLocation(mLastLocation);
         }
-    }
-
-    @Override
-    public boolean onMyLocationButtonClick() {
-        // Return false so that we don't consume the event and the default behavior still occurs
-        // (the camera animates to the user's current position).
-        return false;
-    }
-
-    @Override
-    public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode != MAPS_REQUEST_CODE) return;
-
-        mFindParkingButton.setText(getString(R.string.end_reservation));
-        // Removes the view at the 1st index in the layout (the spot card);
-        mRelativeLayout.removeViewAt(2);
-        mDirectionsPath.remove();
-
-        // Add the current reservation card
-        OccupiedSpotCardView occupiedSpotCardView = new OccupiedSpotCardView(getActivity(),
-                mCurrentSpot);
-        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ConversionUtils.dpToPx(getActivity(), CARD_WIDTH),
-                RelativeLayout.LayoutParams.WRAP_CONTENT);
-        params.addRule(RelativeLayout.ABOVE, R.id.findparkingbutton);
-        params.addRule(RelativeLayout.CENTER_HORIZONTAL);
-        params.bottomMargin = ConversionUtils.dpToPx(getActivity(), CARD_BOTTOM_MARGIN);
-
-        mRelativeLayout.addView(occupiedSpotCardView, params);
     }
 }

--- a/app/src/main/java/com/mmm/parq/fragments/DriverHomeFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverHomeFragment.java
@@ -54,7 +54,9 @@ import com.mmm.parq.utils.NeedsLocation;
 
 import org.json.JSONObject;
 
+import java.sql.Driver;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
@@ -87,6 +89,7 @@ public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
     public interface OnLocationReceivedListener {
         void setLocation(Location location);
         void setReservation(Reservation reservation);
+        Reservation getReservation();
         void setSpot(Spot spot);
     }
 
@@ -126,8 +129,7 @@ public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
         // Watch for when the reservation is initialized and notify people who care
         Thread reservationInitializedThread = new Thread() {
             public void run() {
-                while ((getActivity()) == null ||
-                        ((DriverActivity)getActivity()).getReservation() == null) {
+                while (mCallback.getReservation() == null) {
                    // do nothing
                 }
                 reservationSetLatch.countDown();
@@ -411,7 +413,14 @@ public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
                 try {
                     // If the user has an active reservation.
                     if (response.getJSONObject("attributes").has("activeDriverReservations")) {
-                        String reservationId = response.getJSONObject("attributes").getString("activeDriverReservations");
+                        JSONObject activeReservations = response.getJSONObject("attributes").getJSONObject("activeDriverReservations");
+                        Iterator<String> resKeys = activeReservations.keys();
+                        String reservationId = null;
+                        if (resKeys.hasNext()) {
+                            JSONObject resObj = activeReservations.getJSONObject(resKeys.next());
+                            reservationId = resObj.getString("reservationId");
+                        }
+
                         mState = State.OCCUPY_SPOT;
 
                         // Get the reservation and set it as the activity's current reservation.

--- a/app/src/main/java/com/mmm/parq/fragments/DriverNavigationFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverNavigationFragment.java
@@ -1,0 +1,236 @@
+package com.mmm.parq.fragments;
+
+import android.content.Context;
+import android.content.Intent;
+import android.location.Location;
+import android.net.Uri;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.RelativeLayout;
+
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.Response;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.StringRequest;
+import com.github.davidmoten.geo.GeoHash;
+import com.github.davidmoten.geo.LatLong;
+import com.google.android.gms.maps.model.LatLng;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
+import com.mmm.parq.R;
+import com.mmm.parq.activities.DriverActivity;
+import com.mmm.parq.exceptions.RouteNotFoundException;
+import com.mmm.parq.layouts.ReservedSpotCardView;
+import com.mmm.parq.models.Reservation;
+import com.mmm.parq.models.Spot;
+import com.mmm.parq.utils.ConversionUtils;
+import com.mmm.parq.utils.DirectionsParser;
+import com.mmm.parq.utils.HttpClient;
+import com.mmm.parq.utils.NeedsLocation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class DriverNavigationFragment extends Fragment implements NeedsLocation {
+    private Button mNavigationButton;
+    private Gson mGson;
+    private Location mLocation;
+    private OnDirectionsRequestedListener mCallback;
+    private RelativeLayout mRelativeLayout;
+    private RequestQueue mQueue;
+    private Reservation mReservation;
+    private Spot mSpot;
+
+    static private final int CARD_WIDTH = 380;
+    static private final int CARD_BOTTOM_MARGIN = 4;
+    static private final int MAPS_REQUEST_CODE = 1;
+
+    static private String CLASS = "DriverNavigation";
+
+    public interface OnDirectionsRequestedListener {
+        void drawPathToSpot(List<LatLng> path, LatLong spotLocation);
+        void setSpot(Spot spot);
+        Reservation getReservation();
+    }
+
+    public DriverNavigationFragment() {}
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+                             Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_navigation_driver, container,
+                false);
+
+        Bundle bundle = this.getArguments();
+        mGson = new Gson();
+        mQueue = HttpClient.getInstance(getActivity().getApplicationContext()).getRequestQueue();
+        mRelativeLayout = (RelativeLayout) view.findViewById(R.id.navigation_layout);
+        mReservation = mCallback.getReservation();
+        mLocation = ((DriverActivity) getActivity()).getLocation();
+
+        // Tell the map fragment to draw the directions path.
+        String geohash = mReservation.getAttribute("geohash");
+        final LatLong latLong = GeoHash.decodeHash(geohash);
+        
+        // Request directions to the reserved spot using Google Directions API
+        requestDirections(latLong, new HttpClient.VolleyCallback<String>() {
+            @Override
+            public void onSuccess(String directionsResponse) {
+                DirectionsParser parser = new DirectionsParser(directionsResponse);
+                List<LatLng> path = new ArrayList<>();
+                try {
+                    path = parser.parsePath();
+                } catch (RouteNotFoundException e) {
+                    Log.d(CLASS, "No route found: " + e.toString());
+                }
+
+                final String timeToSpot = parser.parseTime();
+                // Request the spot for this reservation
+                requestSpot(mReservation.getAttribute("spotId"), new HttpClient.VolleyCallback<String>() {
+                    @Override
+                    public void onSuccess(String spotResponse) {
+                        mSpot = parseSpotResponse(spotResponse);
+                        // Tell the activity what the spot is so that it can be shared with other frags
+                        mCallback.setSpot(mSpot);
+
+                        showSpotCard(mSpot, timeToSpot);
+                    }
+
+                    @Override
+                    public void onError(VolleyError error) {
+                        Log.d(CLASS, error.toString());
+                    }
+                });
+
+                // Tell the activity to display the path on the map.
+                mCallback.drawPathToSpot(path, latLong);
+
+                // Update the button
+                mNavigationButton.setText(getString(R.string.navigate_text));
+                Log.d(CLASS, "ABOUT TO REQUEST SPOT");
+            }
+
+            @Override
+            public void onError(VolleyError error) {
+                Log.d(CLASS, error.getMessage());
+            }
+        });
+
+        mNavigationButton = (Button) view.findViewById(R.id.navigate_button);
+        mNavigationButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                startNavigation();
+            }
+        });
+
+        return view;
+    }
+
+    public void setLocation(Location location) {
+        mLocation = location;
+    }
+
+
+    private void startNavigation() {
+        LatLong latLong = GeoHash.decodeHash(mSpot.getAttribute("geohash"));
+        String uriString = String.format(getString(R.string.nav_intent_uri),
+                latLong.getLat(), latLong.getLon());
+        Uri gmmIntentUri = Uri.parse(uriString);
+        Intent mapIntent = new Intent(Intent.ACTION_VIEW, gmmIntentUri);
+        mapIntent.setPackage(getString(R.string.maps_package));
+
+        getParentFragment().startActivityForResult(mapIntent, MAPS_REQUEST_CODE);
+    }
+
+    // Send a request to Google Directions API for directions from the user's current location to their
+    // reserved spot.
+    private void requestDirections(LatLong latLong, final HttpClient.VolleyCallback<String> callback) {
+        String apiKey = getString(R.string.google_maps_key);
+
+        // Request directions
+        String directionsUrl = String.format("%s?origin=%f,%f&destination=%f,%f&key=%s\t\n",
+                getString(R.string.google_directions_endpoint), mLocation.getLatitude(),
+                mLocation.getLongitude(), latLong.getLat(),
+                latLong.getLon(), apiKey);
+        StringRequest directionsRequest = new StringRequest(Request.Method.GET, directionsUrl, new Response.Listener<String>() {
+            @Override
+            public void onResponse(String response) {
+               callback.onSuccess(response);
+            }
+        }, new Response.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError error) {
+                callback.onError(error);
+            }
+        });
+
+        mQueue.add(directionsRequest);
+    }
+
+    private void requestSpot(String spotId, final HttpClient.VolleyCallback<String> callback) {
+        // Request the spot
+        String url = String.format("%s/%s/%s", getString(R.string.api_address),
+                getString(R.string.spots_endpoint), spotId);
+        StringRequest spotRequest = new StringRequest(Request.Method.GET, url, new Response.Listener<String>() {
+            @Override
+            public void onResponse(String response) {
+                callback.onSuccess(response);
+            }
+        }, new Response.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError error) {
+                callback.onError(error);
+            }
+        });
+
+        mQueue.add(spotRequest);
+    }
+
+    private void showSpotCard(Spot spot, String timeToSpot) {
+        ReservedSpotCardView reservedSpotCardView = new ReservedSpotCardView(getActivity(), spot, timeToSpot);
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ConversionUtils.dpToPx(getActivity(), CARD_WIDTH),
+                RelativeLayout.LayoutParams.WRAP_CONTENT);
+        params.addRule(RelativeLayout.ABOVE, R.id.navigate_button);
+        params.addRule(RelativeLayout.CENTER_HORIZONTAL);
+        params.bottomMargin = ConversionUtils.dpToPx(getActivity(), CARD_BOTTOM_MARGIN);
+
+        mRelativeLayout.addView(reservedSpotCardView, params);
+    }
+
+    private Spot parseSpotResponse(String response) {
+        JsonParser parser = new JsonParser();
+        JsonObject spotObj = parser.parse(response).getAsJsonObject();
+        String id = spotObj.get("id").getAsString();
+        JsonObject attrObj = spotObj.get("attributes").getAsJsonObject();
+        HashMap<String, String> attrs = mGson.fromJson(attrObj, new TypeToken<HashMap<String, String>>(){}.getType());
+
+        return new Spot(id, attrs);
+    }
+
+    @Override
+    public void onAttach(Context activity) {
+        super.onAttach(activity);
+
+        // Check that the activity has properly implemented the interface.
+        try {
+            mCallback = (OnDirectionsRequestedListener) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString() + " must implement interface");
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle bundle) {
+
+    }
+}

--- a/app/src/main/java/com/mmm/parq/fragments/DriverOccupiedSpotFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverOccupiedSpotFragment.java
@@ -1,0 +1,64 @@
+package com.mmm.parq.fragments;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.RelativeLayout;
+
+import com.mmm.parq.R;
+import com.mmm.parq.layouts.OccupiedSpotCardView;
+import com.mmm.parq.models.Spot;
+import com.mmm.parq.utils.ConversionUtils;
+
+public class DriverOccupiedSpotFragment extends Fragment {
+    private OnNavigationCompletedListener mCallback;
+    private RelativeLayout mRelativeLayout;
+
+    static private int CARD_WIDTH = 380;
+    static private int CARD_BOTTOM_MARGIN = 4;
+
+    public interface OnNavigationCompletedListener {
+        void clearMap();
+        Spot getSpot();
+    }
+
+    public DriverOccupiedSpotFragment() {}
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        View view = inflater.inflate(R.layout.fragment_spot_occupied_driver, container, false);
+        mRelativeLayout = (RelativeLayout) view.findViewById(R.id.occupied_layout);
+
+        // Clear the map
+        mCallback.clearMap();
+        showReservationCard();
+
+        return view;
+    }
+
+    private void showReservationCard() {
+        OccupiedSpotCardView occupiedSpotCardView = new OccupiedSpotCardView(getActivity(),
+                mCallback.getSpot());
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ConversionUtils.dpToPx(getActivity(), CARD_WIDTH),
+                RelativeLayout.LayoutParams.WRAP_CONTENT);
+        params.addRule(RelativeLayout.ABOVE, R.id.leave_spot_button);
+        params.addRule(RelativeLayout.CENTER_HORIZONTAL);
+        params.bottomMargin = ConversionUtils.dpToPx(getActivity(), CARD_BOTTOM_MARGIN);
+
+        mRelativeLayout.addView(occupiedSpotCardView, params);
+    }
+
+    @Override
+    public void onAttach(Context activity) {
+        super.onAttach(activity);
+
+        try {
+            mCallback = (OnNavigationCompletedListener) activity;
+        } catch(ClassCastException e) {
+            throw new ClassCastException(activity.toString() + " must implement interface");
+        }
+    }
+}

--- a/app/src/main/java/com/mmm/parq/fragments/DriverOccupiedSpotFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverOccupiedSpotFragment.java
@@ -13,7 +13,6 @@ import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
 import com.android.volley.VolleyError;
-import com.android.volley.toolbox.JsonRequest;
 import com.android.volley.toolbox.StringRequest;
 import com.mmm.parq.R;
 import com.mmm.parq.layouts.OccupiedSpotCardView;
@@ -21,9 +20,6 @@ import com.mmm.parq.models.Reservation;
 import com.mmm.parq.models.Spot;
 import com.mmm.parq.utils.ConversionUtils;
 import com.mmm.parq.utils.HttpClient;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class DriverOccupiedSpotFragment extends Fragment {
     private OnNavigationCompletedListener mCallback;
@@ -33,6 +29,8 @@ public class DriverOccupiedSpotFragment extends Fragment {
 
     static private int CARD_WIDTH = 380;
     static private int CARD_BOTTOM_MARGIN = 4;
+
+    static private String TAG = DriverOccupiedSpotFragment.class.getSimpleName();
 
     public interface OnNavigationCompletedListener {
         void clearMap();
@@ -56,7 +54,14 @@ public class DriverOccupiedSpotFragment extends Fragment {
         mRelativeLayout = (RelativeLayout) view.findViewById(R.id.occupied_layout);
 
         // Occupy the spot
-        occupyReservation();
+        if (this.getArguments() != null) {
+            boolean alreadyOccupied = this.getArguments().getBoolean("occupied");
+            if (!alreadyOccupied) {
+                occupyReservation();
+            }
+        } else {
+            occupyReservation();
+        }
 
         // Clear the map
         mCallback.clearMap();

--- a/app/src/main/java/com/mmm/parq/fragments/DriverOccupiedSpotFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverOccupiedSpotFragment.java
@@ -3,19 +3,33 @@ package com.mmm.parq.fragments;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.RelativeLayout;
 
+import com.android.volley.Request;
+import com.android.volley.RequestQueue;
+import com.android.volley.Response;
+import com.android.volley.VolleyError;
+import com.android.volley.toolbox.JsonRequest;
+import com.android.volley.toolbox.StringRequest;
 import com.mmm.parq.R;
 import com.mmm.parq.layouts.OccupiedSpotCardView;
+import com.mmm.parq.models.Reservation;
 import com.mmm.parq.models.Spot;
 import com.mmm.parq.utils.ConversionUtils;
+import com.mmm.parq.utils.HttpClient;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class DriverOccupiedSpotFragment extends Fragment {
     private OnNavigationCompletedListener mCallback;
     private RelativeLayout mRelativeLayout;
+    private Reservation mReservation;
+    private Spot mSpot;
 
     static private int CARD_WIDTH = 380;
     static private int CARD_BOTTOM_MARGIN = 4;
@@ -23,32 +37,32 @@ public class DriverOccupiedSpotFragment extends Fragment {
     public interface OnNavigationCompletedListener {
         void clearMap();
         Spot getSpot();
+        Reservation getReservation();
     }
 
     public DriverOccupiedSpotFragment() {}
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        mSpot = mCallback.getSpot();
+        mReservation = mCallback.getReservation();
+    }
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_spot_occupied_driver, container, false);
         mRelativeLayout = (RelativeLayout) view.findViewById(R.id.occupied_layout);
 
+        // Occupy the spot
+        occupyReservation();
+
         // Clear the map
         mCallback.clearMap();
         showReservationCard();
 
         return view;
-    }
-
-    private void showReservationCard() {
-        OccupiedSpotCardView occupiedSpotCardView = new OccupiedSpotCardView(getActivity(),
-                mCallback.getSpot());
-        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ConversionUtils.dpToPx(getActivity(), CARD_WIDTH),
-                RelativeLayout.LayoutParams.WRAP_CONTENT);
-        params.addRule(RelativeLayout.ABOVE, R.id.leave_spot_button);
-        params.addRule(RelativeLayout.CENTER_HORIZONTAL);
-        params.bottomMargin = ConversionUtils.dpToPx(getActivity(), CARD_BOTTOM_MARGIN);
-
-        mRelativeLayout.addView(occupiedSpotCardView, params);
     }
 
     @Override
@@ -60,5 +74,33 @@ public class DriverOccupiedSpotFragment extends Fragment {
         } catch(ClassCastException e) {
             throw new ClassCastException(activity.toString() + " must implement interface");
         }
+    }
+
+    private void occupyReservation() {
+        String url = String.format("%s/reservations/%s/occupy", getString(R.string.api_address), mReservation.getId());
+        StringRequest occupyRequest = new StringRequest(Request.Method.PUT, url, new Response.Listener<String>() {
+            @Override
+            public void onResponse(String response) {
+            }
+        }, new Response.ErrorListener() {
+            @Override
+            public void onErrorResponse(VolleyError error) {
+                Log.w("Failed occupy request: ", error.toString());
+            }
+        });
+
+        RequestQueue queue = HttpClient.getInstance(getActivity().getApplicationContext()).getRequestQueue();
+        queue.add(occupyRequest);
+    }
+
+    private void showReservationCard() {
+        OccupiedSpotCardView occupiedSpotCardView = new OccupiedSpotCardView(getActivity(), mSpot);
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(ConversionUtils.dpToPx(getActivity(), CARD_WIDTH),
+                RelativeLayout.LayoutParams.WRAP_CONTENT);
+        params.addRule(RelativeLayout.ABOVE, R.id.leave_spot_button);
+        params.addRule(RelativeLayout.CENTER_HORIZONTAL);
+        params.bottomMargin = ConversionUtils.dpToPx(getActivity(), CARD_BOTTOM_MARGIN);
+
+        mRelativeLayout.addView(occupiedSpotCardView, params);
     }
 }

--- a/app/src/main/java/com/mmm/parq/layouts/OccupiedSpotCardView.java
+++ b/app/src/main/java/com/mmm/parq/layouts/OccupiedSpotCardView.java
@@ -3,6 +3,7 @@ package com.mmm.parq.layouts;
 import android.app.Activity;
 import android.content.Context;
 import android.support.v7.widget.CardView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.TextView;
@@ -25,7 +26,7 @@ public class OccupiedSpotCardView extends CardView {
 
     public OccupiedSpotCardView(final Activity activity, Spot spot) {
         super(activity);
-        final int rate = Integer.parseInt(spot.getAttribute("costPerHour"));
+        final double rate = Double.parseDouble(spot.getAttribute("costPerHour"));
         String addr = spot.getAttribute("addr");
 
         LayoutInflater inflater = (LayoutInflater) activity.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
@@ -50,7 +51,7 @@ public class OccupiedSpotCardView extends CardView {
                         mTimeElapsedText.setText(intToTimeString(mTimeElapsed));
                         mNetCostText.setText(String.format(activity.getString(R.string.cost), mNetCost));
                         mTimeElapsed += 1;
-                        mNetCost += rate;
+                        mNetCost += rate / 60.0;
                     }
                 });
             }

--- a/app/src/main/java/com/mmm/parq/models/Reservation.java
+++ b/app/src/main/java/com/mmm/parq/models/Reservation.java
@@ -15,4 +15,8 @@ public class Reservation implements Serializable {
     public String getAttribute(String key)  {
         return attributes.get(key).toString();
     }
+
+    public String getId() {
+       return id;
+    }
 }

--- a/app/src/main/java/com/mmm/parq/models/Reservation.java
+++ b/app/src/main/java/com/mmm/parq/models/Reservation.java
@@ -1,8 +1,9 @@
 package com.mmm.parq.models;
 
+import java.io.Serializable;
 import java.util.HashMap;
 
-public class Reservation {
+public class Reservation implements Serializable {
     private String id;
     private HashMap attributes;
 

--- a/app/src/main/java/com/mmm/parq/models/Spot.java
+++ b/app/src/main/java/com/mmm/parq/models/Spot.java
@@ -1,8 +1,9 @@
 package com.mmm.parq.models;
 
+import java.io.Serializable;
 import java.util.HashMap;
 
-public class Spot {
+public class Spot implements Serializable {
     private String id;
     private HashMap attributes;
 

--- a/app/src/main/java/com/mmm/parq/utils/NeedsLocation.java
+++ b/app/src/main/java/com/mmm/parq/utils/NeedsLocation.java
@@ -1,0 +1,7 @@
+package com.mmm.parq.utils;
+
+import android.location.Location;
+
+public interface NeedsLocation {
+    public void setLocation(Location location);
+}

--- a/app/src/main/res/layout/fragment_find_spot_driver.xml
+++ b/app/src/main/res/layout/fragment_find_spot_driver.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <Button
+        style="@style/Widget.AppCompat.Button"
+        android:id="@+id/findparkingbutton"
+        android:text="@string/find_spot_button_text"
+        android:background="@drawable/rounded_button"
+        android:textColor="@android:color/white"
+        android:textSize="24sp"
+        android:layout_width="380dp"
+        android:layout_height="64dp"
+        android:layout_centerHorizontal="true"
+        android:layout_alignParentBottom="true"
+        android:textAllCaps="false"
+        android:layout_marginBottom="4dp"/>
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_home_driver.xml
+++ b/app/src/main/res/layout/fragment_home_driver.xml
@@ -11,17 +11,9 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         tools:context=".activities.DriverActivity" />
-    <Button
-        style="@style/Widget.AppCompat.Button"
-        android:id="@+id/findparkingbutton"
-        android:text="@string/find_spot_button_text"
-        android:background="@drawable/rounded_button"
-        android:textColor="@android:color/white"
-        android:textSize="24sp"
-        android:layout_width="380dp"
-        android:layout_height="64dp"
-        android:layout_centerHorizontal="true"
-        android:layout_alignParentBottom="true"
-        android:textAllCaps="false"
-        android:layout_marginBottom="4dp"/>
+    <RelativeLayout
+        android:id="@+id/driver_fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+    </RelativeLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/fragment_navigation_driver.xml
+++ b/app/src/main/res/layout/fragment_navigation_driver.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/navigation_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <Button
+        style="@style/Widget.AppCompat.Button"
+        android:id="@+id/navigate_button"
+        android:text="@string/navigate_text"
+        android:background="@drawable/rounded_button"
+        android:textColor="@android:color/white"
+        android:textSize="24sp"
+        android:layout_width="380dp"
+        android:layout_height="64dp"
+        android:layout_centerHorizontal="true"
+        android:layout_alignParentBottom="true"
+        android:textAllCaps="false"
+        android:layout_marginBottom="4dp"/>
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_spot_occupied_driver.xml
+++ b/app/src/main/res/layout/fragment_spot_occupied_driver.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/occupied_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <Button
+        style="@style/Widget.AppCompat.Button"
+        android:id="@+id/leave_spot_button"
+        android:text="@string/end_reservation"
+        android:background="@drawable/rounded_button"
+        android:textColor="@android:color/white"
+        android:textSize="24sp"
+        android:layout_width="380dp"
+        android:layout_height="64dp"
+        android:layout_centerHorizontal="true"
+        android:layout_alignParentBottom="true"
+        android:textAllCaps="false"
+        android:layout_marginBottom="4dp"/>
+</RelativeLayout>


### PR DESCRIPTION
<h1> State Management </h1>

<h2> What? </h2>
- Splits 'DriverHomeFragment' into one parent fragment and 3 child fragments. Each child fragment corresponds to one of the key states a driver can be in: FIND_SPOT, NAVIGATION, OCCUPY_SPOT
- Each child fragment knows how to remember it's state & resume properly
- DriverHomeFragment knows how to remember it's state & resume properly (namely, which child fragment it should display)
- The app now ensures that if the user has an active reservation, they are immediately put in the OCCUPY_SPOT state upon opening the app

<h2> Why? </h2>
- Splitting into fragments makes it far easier to understand what's happening in the code -- with everything in one fragment, we were going to have one button with 3 functions/texts...
- Managing state w/o the fragments would be a mess
- It would suck if the user had a reservation & then couldn't get back to it because the app got killed or whatever

<h2> Key concepts </h2>

There's a few things going on in here that could be kind of confusing: 

<h3> Communication between fragments </h3>

Communicating directly between two fragments is generally frowned upon / not really possible in android. The 'correct' way to handle this is to have the activity manage all communication. The way you implement this is by having the fragments define interfaces that the activity should implement. 

For instance: if my fragment is going to want to tell the activity a location at some point in time, it will define a 'setLocation' method in an interface. The activity implements 'setLocation', so then the fragment can call the 'setLocation' method on the activity when it wants to. If some other fragment wants to know that location, the activity can call a public method of that fragment to share it. 

<h3> The Map </h3>

Just note that the map fragment lives in DriverHomeFragment because it is displayed in all of the child fragments, and we don't want to have to deal with reloading it each time we switch states. This does make things a little bit more complicated because it means that we're dealing with child fragments, but I think it's probably worth it.

This also means that the child fragments have to use the activity in order to interact with the map -- that's why you see methods like 'clearSpot' and 'drawPathToSpot' in the activity now.

<h3> Asynchronous Bullshit </h3> 

We have several variables that are initialized as a result of asynchronous requests (namely, the reservation, the spot, and the user's location). These variables are used throughout the code. Because we can start in any of the 3 child fragments, all of them have to 'wait' on the initialization of some of these vars. 

The simplest way I could find to implement this was using CountDownLatch. Basically this just lets you tell one part of your code to wait for another part to call countDown() on your latch before doing something. You'll frequently see me waiting on a latch inside of a new thread (to avoid blocking the main thread). 

closes #6 

Sorry I know this is a monster. 

@matthewgrossman @nickcharles 
