### PR TITLE
Move spot request code to onStart so it refreshes more frequently

### DIFF
--- a/app/src/main/java/com/mmm/parq/activities/HostActivity.java
+++ b/app/src/main/java/com/mmm/parq/activities/HostActivity.java
@@ -40,6 +40,11 @@ public class HostActivity extends AppCompatActivity {
                 startActivity(i);
             }
         });
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
 
         Firebase firebaseRef = new Firebase(getString(R.string.firebase_endpoint));
         RequestQueue queue = Volley.newRequestQueue(this);

--- a/app/src/main/java/com/mmm/parq/activities/HostActivity.java
+++ b/app/src/main/java/com/mmm/parq/activities/HostActivity.java
@@ -34,8 +34,6 @@ public class HostActivity extends AppCompatActivity {
         fab.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                Snackbar.make(view, "This will add a new spot!", Snackbar.LENGTH_LONG)
-                        .setAction("Action", null).show();
                 Intent i = new Intent(getApplicationContext(), HostNewSpotActivity.class);
                 startActivity(i);
             }


### PR DESCRIPTION
This is untested but yolo. _Shouldn't_ actually break anything, just run the request whenever onStart is called so that we refresh the list of spots more frequently.
