### PR TITLE
Make child fragments retrieve all shared data from the activity using RequestFutures.

### DIFF
--- a/app/src/main/java/com/mmm/parq/activities/HostActivity.java
+++ b/app/src/main/java/com/mmm/parq/activities/HostActivity.java
@@ -25,6 +25,8 @@ public class HostActivity extends AppCompatActivity {
     private GridView mHostSpotsList;
     private JSONArray mSpotsArray;
 
+    private final static String TAG = HostActivity.class.getSimpleName();
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -57,7 +59,7 @@ public class HostActivity extends AppCompatActivity {
         }, new Response.ErrorListener() {
             @Override
             public void onErrorResponse(VolleyError error) {
-                Log.d("HOST", "There was an error getting the users spots: " +  error);
+                Log.e(TAG, "There was an error getting the users spots: " +  error);
             }
         });
         queue.add(jsonArrayRequest);

--- a/app/src/main/java/com/mmm/parq/adapters/SpotAdapter.java
+++ b/app/src/main/java/com/mmm/parq/adapters/SpotAdapter.java
@@ -6,7 +6,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
-import android.widget.GridView;
 import android.widget.TextView;
 
 import com.mmm.parq.R;
@@ -19,46 +18,46 @@ public class SpotAdapter extends BaseAdapter {
     private Context mContext;
     private JSONArray mSpotsArray;
 
-        public SpotAdapter(Context c, JSONArray spotsArray) {
-            Log.d("SPOTADAPTER", "Here we are in the SpotAdapter constructor");
-            mContext = c;
-            mSpotsArray = spotsArray;
-        }
+    private static final String TAG = SpotAdapter.class.getSimpleName();
 
-        public int getCount() {
-            return mSpotsArray.length();
-        }
-
-        public Object getItem(int position) {
-            return null;
-        }
-
-        public long getItemId(int position) {
-            return 0;
-        }
-
-        // create a new TextView for each item referenced by the Adapter
-        public View getView(int position, View convertView, ViewGroup parent) {
-            Log.d("SPOTADAPTER", "This is the beginning of getView and position is: " + position);
-
-            View hostSpotView;
-            if (convertView == null) {
-                // if it's not recycled, initialize some attributes
-                LayoutInflater inflater = (LayoutInflater) mContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-                hostSpotView = inflater.inflate(R.layout.host_spot_display, null);
-            } else {
-                hostSpotView = convertView;
-            }
-
-            try {
-                JSONObject spotObj = mSpotsArray.getJSONObject(position);
-                JSONObject attrs = spotObj.getJSONObject("attributes");
-                String title = attrs.getString("title");
-                TextView textView = (TextView) hostSpotView.findViewById(R.id.host_spot_item);
-                textView.setText(title);
-            } catch (JSONException e) {
-                Log.d("HOST", "Error parsing spots array");
-            }
-            return hostSpotView;
-        }
+    public SpotAdapter(Context c, JSONArray spotsArray) {
+        mContext = c;
+        mSpotsArray = spotsArray;
     }
+
+    public int getCount() {
+                        return mSpotsArray.length();
+                                                                }
+
+    public Object getItem(int position) {
+                                      return null;
+                                                                            }
+
+    public long getItemId(int position) {
+                                      return 0;
+                                                                         }
+
+    // create a new TextView for each item referenced by the Adapter
+    public View getView(int position, View convertView, ViewGroup parent) {
+
+        View hostSpotView;
+        if (convertView == null) {
+            // if it's not recycled, initialize some attributes
+            LayoutInflater inflater = (LayoutInflater) mContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+            hostSpotView = inflater.inflate(R.layout.host_spot_display, null);
+        } else {
+            hostSpotView = convertView;
+        }
+
+        try {
+            JSONObject spotObj = mSpotsArray.getJSONObject(position);
+            JSONObject attrs = spotObj.getJSONObject("attributes");
+            String title = attrs.getString("title");
+            TextView textView = (TextView) hostSpotView.findViewById(R.id.host_spot_item);
+            textView.setText(title);
+        } catch (JSONException e) {
+            Log.e(TAG, "Error parsing spots array");
+        }
+        return hostSpotView;
+    }
+}

--- a/app/src/main/java/com/mmm/parq/fragments/DriverEndReservationFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverEndReservationFragment.java
@@ -35,8 +35,6 @@ public class DriverEndReservationFragment extends Fragment {
     private TextView mAddress;
     private TextView mCost;
 
-
-
     public interface OnChangeFragmentListener {
         void setFragment(Fragment fragment);
     }

--- a/app/src/main/java/com/mmm/parq/fragments/DriverFindSpotFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverFindSpotFragment.java
@@ -1,44 +1,18 @@
 package com.mmm.parq.fragments;
 
-import android.content.Context;
-import android.location.Location;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 
-import com.android.volley.Request;
-import com.android.volley.RequestQueue;
-import com.android.volley.Response;
-import com.android.volley.VolleyError;
-import com.android.volley.toolbox.StringRequest;
-import com.firebase.client.Firebase;
-import com.google.gson.Gson;
 import com.mmm.parq.R;
 import com.mmm.parq.activities.DriverActivity;
-import com.mmm.parq.models.Reservation;
-import com.mmm.parq.utils.HttpClient;
-import com.mmm.parq.utils.NeedsLocation;
 
-import java.util.HashMap;
-import java.util.Map;
-
-public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
+public class DriverFindSpotFragment extends Fragment {
     private Button mFindParkingButton;
-    private Gson mGson;
-    private Location mLocation;
-    private OnReservationCreatedListener mCallback;
-    private RequestQueue mQueue;
-
-    private final String TAG = DriverFindSpotFragment.class.getSimpleName();
-
-    public interface OnReservationCreatedListener {
-        void setReservation(Reservation reservation);
-    }
 
     public DriverFindSpotFragment() {}
 
@@ -47,8 +21,6 @@ public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_find_spot_driver, container, false);
 
-        mGson = new Gson();
-        mQueue = HttpClient.getInstance(getActivity().getApplicationContext()).getRequestQueue();
         mFindParkingButton = (Button) view.findViewById(R.id.findparkingbutton);
         mFindParkingButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -60,70 +32,12 @@ public class DriverFindSpotFragment extends Fragment implements NeedsLocation {
         return view;
     }
 
-    @Override
-    public void onAttach(Context activity) {
-        super.onAttach(activity);
-
-        try {
-            mCallback = (OnReservationCreatedListener) activity;
-        } catch (ClassCastException e) {
-            throw new ClassCastException(activity.toString() + " must implement interface");
-        }
-    }
-
-    public void setLocation(Location location) {
-        mLocation = location;
-    }
-
     private void reserveSpot() {
-        requestReservation(new HttpClient.VolleyCallback<String>() {
-            @Override
-            public void onSuccess(String response) {
-                // Parse the reservation response into a Reservation, send it to activity.
-                Reservation reservation = mGson.fromJson(response, Reservation.class);
-                mCallback.setReservation(reservation);
-
-                // Start the navigation fragment.
-                DriverNavigationFragment driverNavigationFragment = new DriverNavigationFragment();
-                FragmentTransaction fragmentTransaction = getFragmentManager().beginTransaction();
-                fragmentTransaction.replace(R.id.driver_fragment_container, driverNavigationFragment);
-                ((DriverActivity) getActivity()).setState(DriverHomeFragment.State.NAVIGATION);
-                fragmentTransaction.commit();
-                ((DriverActivity) getActivity()).shareLocation();
-            }
-
-            @Override
-            public void onError(VolleyError error) {
-                Log.d(TAG + ":Error", error.toString());
-            }
-        });
-    }
-
-    // Send a request to create a reservation for the current user from the reservations endpoint.
-    private void requestReservation(final HttpClient.VolleyCallback<String> callback) {
-        String url = String.format("%s/%s", getString(R.string.api_address), getString(R.string.reservations_endpoint));
-        StringRequest reservationRequest = new StringRequest(Request.Method.POST, url, new Response.Listener<String>() {
-            @Override
-            public void onResponse(String response) {
-                callback.onSuccess(response);
-            }
-        }, new Response.ErrorListener() {
-            @Override
-            public void onErrorResponse(VolleyError error) {
-                callback.onError(error);
-            }
-        }) {
-            @Override
-            protected Map<String, String> getParams() {
-                Map<String, String>  params = new HashMap<>();
-                Firebase firebaseRef = new Firebase(getString(R.string.firebase_endpoint));
-                params.put("userId", firebaseRef.getAuth().getUid());
-                params.put("latitude", String.valueOf(mLocation.getLatitude()));
-                params.put("longitude", String.valueOf(mLocation.getLongitude()));
-                return params;
-            }
-        };
-
-        mQueue.add(reservationRequest);
+        // Start the navigation fragment.
+        DriverNavigationFragment driverNavigationFragment = new DriverNavigationFragment();
+        FragmentTransaction fragmentTransaction = getFragmentManager().beginTransaction();
+        fragmentTransaction.replace(R.id.driver_fragment_container, driverNavigationFragment);
+        ((DriverActivity) getActivity()).setState(DriverHomeFragment.State.NAVIGATION);
+        fragmentTransaction.commit();
     }
 }

--- a/app/src/main/java/com/mmm/parq/interfaces/HasLocation.java
+++ b/app/src/main/java/com/mmm/parq/interfaces/HasLocation.java
@@ -1,0 +1,8 @@
+package com.mmm.parq.interfaces;
+
+import android.location.Location;
+
+public interface HasLocation {
+    void setLocation(Location location);
+    Location getLocation();
+}

--- a/app/src/main/java/com/mmm/parq/interfaces/HasReservation.java
+++ b/app/src/main/java/com/mmm/parq/interfaces/HasReservation.java
@@ -1,0 +1,9 @@
+package com.mmm.parq.interfaces;
+
+import com.mmm.parq.models.Reservation;
+
+import java.util.concurrent.FutureTask;
+
+public interface HasReservation {
+    FutureTask<Reservation> getReservation(String spotId);
+}

--- a/app/src/main/java/com/mmm/parq/interfaces/HasSpot.java
+++ b/app/src/main/java/com/mmm/parq/interfaces/HasSpot.java
@@ -1,0 +1,9 @@
+package com.mmm.parq.interfaces;
+
+import com.mmm.parq.models.Spot;
+
+import java.util.concurrent.FutureTask;
+
+public interface HasSpot {
+    FutureTask<Spot> getSpot(String spotId);
+}

--- a/app/src/main/java/com/mmm/parq/interfaces/MapController.java
+++ b/app/src/main/java/com/mmm/parq/interfaces/MapController.java
@@ -1,0 +1,13 @@
+package com.mmm.parq.interfaces;
+
+import com.github.davidmoten.geo.LatLong;
+import com.google.android.gms.maps.model.LatLng;
+
+import java.util.List;
+
+public interface MapController {
+    void addDestinationMarker(LatLong latLong);
+    void clearMap();
+    void drawPathToSpot(List<LatLng> path, LatLong spotLocation);
+    void zoomCameraToDestinationMarker();
+}

--- a/app/src/main/java/com/mmm/parq/interfaces/NeedsLocation.java
+++ b/app/src/main/java/com/mmm/parq/interfaces/NeedsLocation.java
@@ -1,4 +1,4 @@
-package com.mmm.parq.utils;
+package com.mmm.parq.interfaces;
 
 import android.location.Location;
 

--- a/app/src/main/java/com/mmm/parq/models/Directions.java
+++ b/app/src/main/java/com/mmm/parq/models/Directions.java
@@ -1,0 +1,28 @@
+package com.mmm.parq.models;
+
+import com.google.android.gms.maps.model.LatLng;
+
+import java.util.List;
+
+public class Directions {
+    private List<LatLng> mPath;
+    private String mTimeToSpot;
+
+    public List<LatLng> getPath() {
+        return mPath;
+    }
+
+    public String getTimeToSpot() {
+        return mTimeToSpot;
+    }
+
+    public void setTimeToSpot(String mTimeToSpot) {
+        this.mTimeToSpot = mTimeToSpot;
+    }
+
+    public void setPath(List<LatLng> mPath) {
+        this.mPath = mPath;
+    }
+
+    public Directions() {}
+}


### PR DESCRIPTION
<h1> Yet another pr that doesn't actually make visible changes. </h1>


<h2> What and Why? </h2>

This PR updates the way that we handle accessing pieces of data that are shared by multiple fragments. 
- previously, if a fragment needed something (say a spot), it would either send the request to get the spot itself, or trust that the activity already knew what the spot was (depending on which state the fragment corresponded to). 
- This was a shitty system -- it was hard to follow, and meant that multiple fragments were making the same requests.
- Now any shared resource is managed by the activity. A fragment can just say: 

```
mSpot = mCallback.getSpot(spotId).get();
```

to retrieve a resource from the activity. get[Resource] returns a RequestFuture, which essentially acts like a promise. The call to '.get()' will wait until the Future resolves, and then return it's value. This is a blocking call, thus it must be done in a separate thread. 

Note that when the activity returns a resource, it first checks to see if it already has the resource; if it doesn't, it makes the request to the backend to retrieve it. 

<h2> Other stuff </h2>

I also made the interfaces we use more clear, and added a few 'global' interfaces that multiple fragments implement. 

@nickcharles @matthewgrossman 
