### PR TITLE
Ensure that spots are eventually freed if the user leaves the app while it's in the pre-nav state.

### DIFF
--- a/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
+++ b/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
@@ -66,6 +66,7 @@ public class DriverActivity extends FragmentActivity implements
     private RequestQueue mQueue;
     private Reservation mReservation;
     private Spot mSpot;
+    private DriverHomeFragment.State mState;
     private TextView mNameView;
     private User mUser;
     private Location mUserLocation;
@@ -237,6 +238,15 @@ public class DriverActivity extends FragmentActivity implements
     }
 
     @Override
+    public void removeEndMarker() {
+        try {
+            ( (DriverHomeFragment) mFragment).removeEndMarker();
+        } catch (ClassCastException e) {
+            Log.d("DriverActivity", "Invalid Fragment");
+        }
+    }
+
+    @Override
     public void addDestinationMarker(LatLong latLong) {
         ((DriverHomeFragment) mFragment).addDestinationMarker(latLong);
     }
@@ -262,8 +272,14 @@ public class DriverActivity extends FragmentActivity implements
     public void setState(DriverHomeFragment.State state) {
         try {
             DriverHomeFragment driverHomeFrag = ((DriverHomeFragment) mFragment);
+            mState = state;
             driverHomeFrag.setState(state);
         } catch(ClassCastException e) {}
+    }
+
+    @Override
+    public DriverHomeFragment.State getState() {
+        return mState;
     }
 
     // Implementing HasReservation Interface

--- a/app/src/main/java/com/mmm/parq/fragments/DriverFindSpotFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverFindSpotFragment.java
@@ -1,5 +1,6 @@
 package com.mmm.parq.fragments;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentTransaction;
@@ -10,9 +11,11 @@ import android.widget.Button;
 
 import com.mmm.parq.R;
 import com.mmm.parq.activities.DriverActivity;
+import com.mmm.parq.interfaces.MapController;
 
 public class DriverFindSpotFragment extends Fragment {
     private Button mFindParkingButton;
+    private MapController mCallback;
 
     public DriverFindSpotFragment() {}
 
@@ -20,6 +23,10 @@ public class DriverFindSpotFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_find_spot_driver, container, false);
+
+        // Clear the map
+        mCallback.clearMap();
+        mCallback.removeEndMarker();
 
         mFindParkingButton = (Button) view.findViewById(R.id.findparkingbutton);
         mFindParkingButton.setOnClickListener(new View.OnClickListener() {
@@ -31,6 +38,18 @@ public class DriverFindSpotFragment extends Fragment {
 
         return view;
     }
+
+    @Override
+    public void onAttach(Context activity) {
+        super.onAttach(activity);
+
+        try {
+            mCallback = (MapController) activity;
+        } catch (ClassCastException e) {
+            throw new ClassCastException(activity.toString() + " must implement interface");
+        }
+    }
+
 
     private void reserveSpot() {
         // Start the navigation fragment.

--- a/app/src/main/java/com/mmm/parq/fragments/DriverHomeFragment.java
+++ b/app/src/main/java/com/mmm/parq/fragments/DriverHomeFragment.java
@@ -200,6 +200,13 @@ public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
         savedInstanceState.putSerializable("state", mState);
     }
 
+    @Override
+    public void onStart() {
+        super.onStart();
+
+        setOverlayFragment();
+    }
+
     public void setOverlayFragment() {
         Fragment fragment = null;
         Bundle args = new Bundle();
@@ -227,7 +234,7 @@ public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
                 fragment = new DriverEndReservationFragment();
                 break;
         }
-        getChildFragmentManager().beginTransaction().add(R.id.driver_fragment_container, fragment).commit();
+        getChildFragmentManager().beginTransaction().replace(R.id.driver_fragment_container, fragment).commit();
     }
 
     public void setLocation(Location location) {
@@ -269,7 +276,16 @@ public class DriverHomeFragment extends Fragment implements OnMapReadyCallback,
             Log.w(TAG, "No start marker!");
             return;
         }
+        mStartMarker.remove();
         zoomCameraToDestinationMarker();;
+    }
+
+    public void removeEndMarker() {
+        if (mDestMarker == null) {
+            Log.w(TAG, "No start marker!");
+            return;
+        }
+        mDestMarker.remove();
     }
 
     private void zoomCameraToMarkers(List<Marker> markers) {

--- a/app/src/main/java/com/mmm/parq/interfaces/MapController.java
+++ b/app/src/main/java/com/mmm/parq/interfaces/MapController.java
@@ -8,6 +8,7 @@ import java.util.List;
 public interface MapController {
     void addDestinationMarker(LatLong latLong);
     void clearMap();
+    void removeEndMarker();
     void drawPathToSpot(List<LatLng> path, LatLong spotLocation);
     void zoomCameraToDestinationMarker();
 }

--- a/app/src/main/java/com/mmm/parq/interfaces/NeedsState.java
+++ b/app/src/main/java/com/mmm/parq/interfaces/NeedsState.java
@@ -4,4 +4,5 @@ import com.mmm.parq.fragments.DriverHomeFragment;
 
 public interface NeedsState {
     void setState(DriverHomeFragment.State state);
+    DriverHomeFragment.State getState();
 }


### PR DESCRIPTION
<h1> What? </h1>

This PR ensure that if the user leaves the app while in the state immediately before navigation, the spot is eventually freed.

<h1> Why? </h1> 

Obviously we don't want spots to be indefinitely reserved. 

We don't want to free up the spot as soon as the user leaves the app because they could just be leaving for a short period of time -- e.g. they may be leaving the app to confirm the address they're going to, and intend on coming right back to start navigation. Thus, we wait for some set amount of time after they leave the app before we free the spot & set the app's state to FIND_SPOT (5 minutes right now).

Furthermore, we don't want to only free the spot in OnDestroy, because the user could theoretically leave the app (without killing it) and not come back for a really long time.

fixes #24

@matthewgrossman @nickcharles 
