### PR TITLE
Nick/modify nav menu

### DIFF
--- a/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
+++ b/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
@@ -203,14 +203,6 @@ public class DriverActivity extends AppCompatActivity implements
         view.setNavigationItemSelectedListener(new NavigationView.OnNavigationItemSelectedListener() {
             @Override
             public boolean onNavigationItemSelected(MenuItem menuItem) {
-                Snackbar.make(mDrawerLayout, menuItem.getTitle() + " pressed", Snackbar.LENGTH_LONG).show();
-
-                // Check new item & uncheck old one.
-                menuItem.setChecked(true);
-                if (mPreviousItem != null) {
-                    mPreviousItem.setChecked(false);
-                }
-
                 // Display the fragment corresponding to this menu item.
                 FragmentManager fragmentManager = getSupportFragmentManager();
                 switch (menuItem.getItemId()) {
@@ -224,7 +216,7 @@ public class DriverActivity extends AppCompatActivity implements
                         mFragment = new DriverHistoryFragment();
                         break;
                     case R.id.drawer_settings:
-                        //mFragment = new DriverSettingsFragment();
+                        // mFragment = new DriverSettingsFragment();
                         logOut();
                         break;
                     case R.id.drawer_host:

--- a/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
+++ b/app/src/main/java/com/mmm/parq/activities/DriverActivity.java
@@ -215,13 +215,16 @@ public class DriverActivity extends AppCompatActivity implements
                     case R.id.drawer_history:
                         mFragment = new DriverHistoryFragment();
                         break;
-                    case R.id.drawer_settings:
-                        // mFragment = new DriverSettingsFragment();
-                        logOut();
-                        break;
+                    // case R.id.drawer_settings:
+                    //    mFragment = new DriverSettingsFragment();
+                    //    break;
                     case R.id.drawer_host:
                         Intent i = new Intent(DriverActivity.this, HostActivity.class);
                         startActivity(i);
+                        break;
+                    case R.id.drawer_logout:
+                        logOut();
+                        break;
                 }
 
                 if (mFragment != null) {

--- a/app/src/main/res/drawable/ic_work_24dp.xml
+++ b/app/src/main/res/drawable/ic_work_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M20,6h-4V4c0,-1.11 -0.89,-2 -2,-2h-4c-1.11,0 -2,0.89 -2,2v2H4c-1.11,0 -1.99,0.89 -1.99,2L2,19c0,1.11 0.89,2 2,2h16c1.11,0 2,-0.89 2,-2V8c0,-1.11 -0.89,-2 -2,-2zm-6,0h-4V4h4v2z"/>
+</vector>

--- a/app/src/main/res/menu/driver_nav_menu.xml
+++ b/app/src/main/res/menu/driver_nav_menu.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
-    <group
-        android:id="@+id/driver_menu_options"
-        android:checkableBehavior="single" >
+    <group android:checkableBehavior="single">
 
         <item
             android:id="@+id/drawer_home"
@@ -20,21 +18,37 @@
             android:icon="@drawable/ic_restore_24dp"
             android:title="@string/history" />
 
+        <!--
+        This is where the settings item would go
         <item
             android:id="@+id/drawer_settings"
             android:icon="@drawable/ic_settings_24dp"
-            android:title="@string/logout" />
+            android:title="@string/settings" />
+            -->
 
     </group>
 
-    <group
-        android:id="@+id/host_menu_options"
-        android:checkableBehavior="none" >
+    <!-- Blank dummy item-->
+    <item
+        android:title=""
+        android:enabled="false" />
+
+    <group android:checkableBehavior="none">
 
         <item
             android:id="@+id/drawer_host"
             android:icon="@drawable/ic_home_24dp"
             android:title="@string/host" />
+
+        <!-- Blank dummy item-->
+        <item
+            android:title=""
+            android:enabled="false" />
+
+        <item
+            android:id="@+id/drawer_logout"
+            android:icon="@drawable/ic_work_24dp"
+            android:title="@string/logout" />
 
     </group>
 </menu>

--- a/app/src/main/res/menu/driver_nav_menu.xml
+++ b/app/src/main/res/menu/driver_nav_menu.xml
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <group
+        android:id="@+id/driver_menu_options"
+        android:checkableBehavior="single" >
 
-    <item
-        android:id="@+id/drawer_home"
-        android:checked="true"
-        android:icon="@drawable/ic_place_24dp"
-        android:title="@string/home"/>
+        <item
+            android:id="@+id/drawer_home"
+            android:checked="true"
+            android:icon="@drawable/ic_place_24dp"
+            android:title="@string/home" />
 
-    <item
-        android:id="@+id/drawer_payment"
-        android:icon="@drawable/ic_credit_card_24dp"
-        android:title="@string/payment"/>
+        <item
+            android:id="@+id/drawer_payment"
+            android:icon="@drawable/ic_credit_card_24dp"
+            android:title="@string/payment" />
 
-    <item
-        android:id="@+id/drawer_history"
-        android:icon="@drawable/ic_restore_24dp"
-        android:title="@string/history"/>
+        <item
+            android:id="@+id/drawer_history"
+            android:icon="@drawable/ic_restore_24dp"
+            android:title="@string/history" />
 
-    <item
-        android:id="@+id/drawer_settings"
-        android:icon="@drawable/ic_settings_24dp"
-        android:title="@string/logout"/>
+        <item
+            android:id="@+id/drawer_settings"
+            android:icon="@drawable/ic_settings_24dp"
+            android:title="@string/logout" />
 
-    <item
-        android:id="@+id/drawer_host"
-        android:icon="@drawable/ic_home_24dp"
-        android:title="@string/host"/>
+    </group>
 
+    <group
+        android:id="@+id/host_menu_options"
+        android:checkableBehavior="none" >
+
+        <item
+            android:id="@+id/drawer_host"
+            android:icon="@drawable/ic_home_24dp"
+            android:title="@string/host" />
+
+    </group>
 </menu>


### PR DESCRIPTION
This creates gaps between the driver options, the host option, and the logout option in the nav menu. Honestly, it doesn't look great, but it looks a bit better than before and it creates a logical distinction between the items. This is an attempt at a solution for the issue #56 where Max was confused by there not being a back button on the driver options. Play with it and see if you like it. If not, whatever.

This also removes some unnecessary code that showed a snackbar for debugging and did some item checking, as that can be done with a single line in XML.

@kenzshelley @matthewgrossman 
