### PR TITLE
Make the design of the spot details page and the spot rating page match

### DIFF
--- a/app/src/main/res/layout/fragment_driver_review.xml
+++ b/app/src/main/res/layout/fragment_driver_review.xml
@@ -19,6 +19,7 @@
         android:textAlignment="center"
         android:layout_marginTop="16dp"
         android:textSize="34dp"
+        android:textColor="@color/colorPrimaryDark"
         android:layout_below="@+id/spot_image"
         tools:text="$8.54"/>
     <TextView
@@ -30,6 +31,18 @@
         android:textAlignment="center"
         android:layout_below="@+id/cost"
         tools:text="1234 South University Ave"/>
+
+    <View
+        android:id="@+id/review_spot_separator"
+        android:layout_height="1dp"
+        android:layout_width="match_parent"
+        android:background="#90909090"
+        android:layout_below="@+id/spot_addr"
+        android:layout_marginBottom="15dp"
+        android:layout_marginTop="15dp"
+        android:layout_marginLeft="20dp"
+        android:layout_marginRight="20dp" />
+
     <TextView
         android:id="@+id/rate_spot_text"
         android:layout_width="match_parent"
@@ -38,7 +51,7 @@
         android:textStyle="italic"
         android:textSize="16dp"
         android:textAlignment="center"
-        android:layout_below="@+id/spot_addr"
+        android:layout_below="@+id/review_spot_separator"
         android:text="Rate this spot"/>
     <RatingBar
         android:id="@+id/rating_bar"

--- a/app/src/main/res/layout/fragment_driver_review.xml
+++ b/app/src/main/res/layout/fragment_driver_review.xml
@@ -36,7 +36,7 @@
         android:id="@+id/review_spot_separator"
         android:layout_height="1dp"
         android:layout_width="match_parent"
-        android:background="#90909090"
+        android:background="@color/separatorColor"
         android:layout_below="@+id/spot_addr"
         android:layout_marginBottom="15dp"
         android:layout_marginTop="15dp"

--- a/app/src/main/res/layout/fragment_host_spot_details.xml
+++ b/app/src/main/res/layout/fragment_host_spot_details.xml
@@ -29,7 +29,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginBottom="10dp"
-            android:textSize="22sp"
+            android:textSize="34sp"
             android:textColor="@color/colorPrimaryDark"
             tools:text="Spot Title" />
 
@@ -37,8 +37,7 @@
             android:id="@+id/details_spot_addr"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="20sp"
-            android:textColor="@color/colorPrimaryDark"
+            android:textSize="18sp"
             tools:text="Spot Address" />
 
         <View
@@ -49,6 +48,15 @@
             android:layout_marginTop="15dp"
             android:layout_marginLeft="20dp"
             android:layout_marginRight="20dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:textStyle="italic"
+            android:textSize="16sp"
+            android:textAlignment="center"
+            android:text="@string/spot_rating"/>
 
         <RatingBar
             android:id="@+id/details_spot_rating"

--- a/app/src/main/res/layout/fragment_host_spot_details.xml
+++ b/app/src/main/res/layout/fragment_host_spot_details.xml
@@ -43,7 +43,7 @@
         <View
             android:layout_height="1dp"
             android:layout_width="match_parent"
-            android:background="#90909090"
+            android:background="@color/separatorColor"
             android:layout_marginBottom="15dp"
             android:layout_marginTop="15dp"
             android:layout_marginLeft="20dp"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
     <color name="colorAccentDark">#C51162</color>
     <color name="colorAccentLight">#FF80AB</color>
     <color name="textColorPrimary">#FFFFFF</color>
+    <color name="separatorColor">#90909090</color>
     <color name="toolbarTransparent">#00FFFFFF</color>
     <color name="vacantGreen">#64DD17</color>
     <color name="occupiedPurple">#AA00FF</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
 
     <!--Spot Detail Strings-->
     <string name="host_spot_details_titlebar">Spot Details</string>
+    <string name="spot_rating">Spot Rating</string>
     <string name="num_ratings">Number of Ratings: %d</string>
     <string name="occupied">Occupied</string>
     <string name="vacant">Vacant</string>


### PR DESCRIPTION
The design on the spot details page and the spot rating page is now more coherent and symmetric. This addresses issue #60 as brought up by Max in our chat.

@kenzshelley @matthewgrossman   
